### PR TITLE
Fix clerk logo display and styling

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -53,7 +53,7 @@ export default function AboutPage() {
             target="_blank"
             className="transition-opacity hover:opacity-70"
           >
-            <ClerkLogo className="align-baseline h-[14px] w-auto" />
+            <ClerkLogo className="inline align-middle h-[14px] w-auto" />
           </a>{" "}
           obsessing over developer experience, for humans and agents, and
           building a great product.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -53,7 +53,7 @@ export default function AboutPage() {
             target="_blank"
             className="transition-opacity hover:opacity-70"
           >
-            <ClerkLogo className="inline align-middle h-[16px] w-auto" />
+            <ClerkLogo className="inline align-middle mt-[-3px] h-[16px] w-auto" />
           </a>{" "}
           obsessing over developer experience, for humans and agents, and
           building a great product.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -53,7 +53,7 @@ export default function AboutPage() {
             target="_blank"
             className="transition-opacity hover:opacity-70"
           >
-            <ClerkLogo className="inline align-middle h-[14px] w-auto" />
+            <ClerkLogo className="inline align-middle h-[16px] w-auto" />
           </a>{" "}
           obsessing over developer experience, for humans and agents, and
           building a great product.

--- a/components/clerk-logo.tsx
+++ b/components/clerk-logo.tsx
@@ -3,7 +3,7 @@ export function ClerkLogo({ className }: { className?: string }) {
     <>
       {/* Light mode logo (dark text) - shown in light mode only */}
       <svg
-        className={`dark:hidden ${className ?? ""}`}
+        className={`inline-block dark:hidden ${className ?? ""}`}
         viewBox="0 0 441 128"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -27,7 +27,7 @@ export function ClerkLogo({ className }: { className?: string }) {
 
       {/* Dark mode logo (white text) - shown in dark mode only */}
       <svg
-        className={`hidden dark:inline ${className ?? ""}`}
+        className={`hidden dark:inline-block ${className ?? ""}`}
         viewBox="0 0 441 128"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/components/clerk-logo.tsx
+++ b/components/clerk-logo.tsx
@@ -1,9 +1,11 @@
+import { cn } from "lib/cn";
+
 export function ClerkLogo({ className }: { className?: string }) {
   return (
     <>
       {/* Light mode logo (dark text) - shown in light mode only */}
       <svg
-        className={`inline-block dark:hidden ${className ?? ""}`}
+        className={cn(className, "inline-block dark:hidden")}
         viewBox="0 0 441 128"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -27,7 +29,7 @@ export function ClerkLogo({ className }: { className?: string }) {
 
       {/* Dark mode logo (white text) - shown in dark mode only */}
       <svg
-        className={`hidden dark:inline-block ${className ?? ""}`}
+        className={cn(className, "hidden dark:inline-block")}
         viewBox="0 0 441 128"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Correct ClerkLogo component to display only the appropriate light or dark variant and fix its alignment on the about page.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bc2c159-b760-4820-aa30-fd24041270ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9bc2c159-b760-4820-aa30-fd24041270ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes ClerkLogo to render the correct light/dark variant with proper display classes and tweaks its alignment/size on the About page.
> 
> - **Components**:
>   - `components/clerk-logo.tsx`: Use `cn` to compose classes; ensure light logo is `inline-block dark:hidden` and dark logo is `hidden dark:inline-block` for correct theme-specific rendering.
> - **About Page**:
>   - `app/about/page.tsx`: Adjust `ClerkLogo` classes to align inline and tweak size (`inline align-middle mt-[-3px] h-[16px] w-auto`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed9142debecdbbae08fe03395809bce2a0334a47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->